### PR TITLE
docs: use terraform registry instead of git installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ This module requires Terraform >= 0.12.
 
 ```hcl
 module "adfinis-governance" {
-  source = "git::ssh://git@github.com:adfinis/terraform-azurerm-adfinis-governance.git"
+  source  = "adfinis/adfinis-governance/azurerm"
+  version = ">=0.1.0"
 
   beneficiary = "adfinis"
   billto      = "clarkkent"


### PR DESCRIPTION
Now that we have a [release on terraform registry](https://registry.terraform.io/modules/adfinis/adfinis-governance/azurerm/latest) we can install from the registry and pin versions :smiley: 